### PR TITLE
docs: Point image metadata and README at this repository

### DIFF
--- a/r-debug/Dockerfile
+++ b/r-debug/Dockerfile
@@ -12,7 +12,7 @@ FROM ubuntu:22.04
 COPY date.txt /date.txt
 
 LABEL maintainer="cynkra <team@cynkra.com>"
-LABEL org.opencontainers.image.source="https://github.com/cynkra/docker-images"
+LABEL org.opencontainers.image.source="https://github.com/cynkra/r-debug"
 
 # =====================================================================
 # R

--- a/r-debug/README.md
+++ b/r-debug/README.md
@@ -31,7 +31,7 @@ Each image provides different builds of R-devel:
 For general memory debugging with good performance, start with the SAN build:
 
 ```bash
-docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/docker-images/r-debug-san:latest
+docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/r-debug/r-debug-san:latest
 RDsan
 ```
 
@@ -39,25 +39,25 @@ RDsan
 
 **Valgrind (slowest but most thorough):**
 ```bash
-docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/docker-images/r-debug-valgrind:latest
+docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/r-debug/r-debug-valgrind:latest
 RDvalgrind -d valgrind
 ```
 
 **Clang Sanitizers (good performance):**
 ```bash
-docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/docker-images/r-debug-csan:latest
+docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/r-debug/r-debug-csan:latest
 RDcsan
 ```
 
 **Thread Safety Checking:**
 ```bash
-docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/docker-images/r-debug-threadcheck:latest
+docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/r-debug/r-debug-threadcheck:latest
 RDthreadcheck
 ```
 
 **Strict Barrier Checking:**
 ```bash
-docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/docker-images/r-debug-strictbarrier:latest
+docker run --rm -ti --security-opt seccomp=unconfined ghcr.io/cynkra/r-debug/r-debug-strictbarrier:latest
 RDstrictbarrier
 # In R: gctorture(TRUE) or gctorture2(1, inhibit_release=TRUE)
 ```

--- a/r-debug/csan/Dockerfile
+++ b/r-debug/csan/Dockerfile
@@ -8,7 +8,7 @@
 FROM ghcr.io/cynkra/r-debug/r-debug:latest
 
 LABEL maintainer="cynkra <team@cynkra.com>"
-LABEL org.opencontainers.image.source="https://github.com/cynkra/docker-images"
+LABEL org.opencontainers.image.source="https://github.com/cynkra/r-debug"
 
 RUN \
     /tmp/buildR.sh csan && \

--- a/r-debug/duckdb/Dockerfile
+++ b/r-debug/duckdb/Dockerfile
@@ -8,7 +8,7 @@
 FROM ghcr.io/cynkra/r-debug/r-debug:latest
 
 LABEL maintainer="cynkra <team@cynkra.com>"
-LABEL org.opencontainers.image.source="https://github.com/cynkra/docker-images"
+LABEL org.opencontainers.image.source="https://github.com/cynkra/r-debug"
 
 RUN \
     apt-get update && \

--- a/r-debug/san/Dockerfile
+++ b/r-debug/san/Dockerfile
@@ -8,7 +8,7 @@
 FROM ghcr.io/cynkra/r-debug/r-debug:latest
 
 LABEL maintainer="cynkra <team@cynkra.com>"
-LABEL org.opencontainers.image.source="https://github.com/cynkra/docker-images"
+LABEL org.opencontainers.image.source="https://github.com/cynkra/r-debug"
 
 RUN \
     /tmp/buildR.sh san && \

--- a/r-debug/strictbarrier/Dockerfile
+++ b/r-debug/strictbarrier/Dockerfile
@@ -8,7 +8,7 @@
 FROM ghcr.io/cynkra/r-debug/r-debug:latest
 
 LABEL maintainer="cynkra <team@cynkra.com>"
-LABEL org.opencontainers.image.source="https://github.com/cynkra/docker-images"
+LABEL org.opencontainers.image.source="https://github.com/cynkra/r-debug"
 
 # RDstrictbarrier: Make sure that R objects are protected properly.
 RUN \

--- a/r-debug/threadcheck/Dockerfile
+++ b/r-debug/threadcheck/Dockerfile
@@ -8,7 +8,7 @@
 FROM ghcr.io/cynkra/r-debug/r-debug:latest
 
 LABEL maintainer="cynkra <team@cynkra.com>"
-LABEL org.opencontainers.image.source="https://github.com/cynkra/docker-images"
+LABEL org.opencontainers.image.source="https://github.com/cynkra/r-debug"
 
 # RDthreadcheck: Make sure that R's memory management functions are called
 # only from the main R thread.

--- a/r-debug/valgrind/Dockerfile
+++ b/r-debug/valgrind/Dockerfile
@@ -8,7 +8,7 @@
 FROM ghcr.io/cynkra/r-debug/r-debug:latest
 
 LABEL maintainer="cynkra <team@cynkra.com>"
-LABEL org.opencontainers.image.source="https://github.com/cynkra/docker-images"
+LABEL org.opencontainers.image.source="https://github.com/cynkra/r-debug"
 
 # RDvalgrind: Install R-devel with valgrind level 2 instrumentation
 RUN \


### PR DESCRIPTION
## Why

These images moved here from `cynkra/docker-images`,
but the `org.opencontainers.image.source` labels and the `docker run` examples in the README
still named the old repository.

That is not merely cosmetic.
GHCR uses `org.opencontainers.image.source` to link a published package back to its source repository,
so a stale value points users at images that are no longer rebuilt.
The images under `ghcr.io/cynkra/docker-images` were last built on 2026-03-30;
the ones published from here are rebuilt nightly.

This mattered in practice:
`igraph/rigraph`'s sanitizer job was still pulling the stale `r-debug-csan-igraph`
and had been failing to compile against its four-month-old R-devel snapshot
(igraph/rigraph#2802).

## What changed

- `org.opencontainers.image.source` in all seven Dockerfiles
  (`r-debug`, `san`, `csan`, `valgrind`, `strictbarrier`, `threadcheck`, `duckdb`)
  now points at `https://github.com/cynkra/r-debug`.
- The `docker run` examples in `r-debug/README.md` now use `ghcr.io/cynkra/r-debug/r-debug-*`
  instead of `ghcr.io/cynkra/docker-images/r-debug-*`.

Metadata and documentation only — no change to how any image is built.

## Verification

The current `csan` image was exercised while debugging igraph/rigraph#2802:
built 2026-07-28 01:57Z, carrying R-devel 2026-07-27 r90310 and clang 17.0.6,
and it builds and tests rigraph cleanly.

https://claude.ai/code/session_01FcwDG9RDPdiXBjqw8zvUNu